### PR TITLE
Two small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ WIEN2K_SOURCE ?= WIEN2k_23.2.tar
 
 wien2k:
 	cp $(WIEN2K_SOURCE) stack/wien2k
-	@source_file=`basename "$$WIEN2K_SOURCE"` ;\
-	docker build -t wien2k stack/wien2k --build-arg WIEN2K_SOURCE=$$source_file ;\
+	@source_file=`basename ${WIEN2K_SOURCE}` &&\
+	docker build -t wien2k stack/wien2k --build-arg WIEN2K_SOURCE=$$source_file &&\
 	rm stack/wien2k/$$source_file
 
 aiida: wien2k

--- a/stack/wien2k/siteconfig_lapw_inputs
+++ b/stack/wien2k/siteconfig_lapw_inputs
@@ -15,7 +15,7 @@ lib
 fftw3
 Y
 R
-/usr/lib/aarch64-linux-gnu/openblas-pthread/libopenblas.so.0 -lpthread
+/usr/lib/`$uname -m`-linux-gnu/openblas-pthread/libopenblas.so.0 -lpthread
 S
 
 y


### PR DESCRIPTION
Dear mberckx,

Peter Blaha shared your repository with me, as we had discussed the possibility of a docker container for Wien2k at some point. I tried to run your container and ran into two small issues:

1. Something seemed to be wrong with the variable substitution in the makefile. I'm not a GNU make expert, but with the following changes it works for me.
2. I suspect you use a Mac with Apple silicon, as the architecture of openblas was hardcoded to 'aarch64' in the siteconfig inputs. I changed it to `$uname -m` which should expand to the architecture of the system (x86_64 in my case). With this change, the setup should be portable.

I opened this PR as I thought you might be interested in these changes.

Best regards,
Jan Doumont